### PR TITLE
bugfix: pg numeric datatypes must be cast to Number

### DIFF
--- a/server/data_access.mjs
+++ b/server/data_access.mjs
@@ -21,14 +21,14 @@ export default function({db, paypoint_schema_name}) {
 
 	const get_payment = async function({ external_id }) {
 		let result = (await db.query(GET_PAYMENT_SQL, [external_id])).rows[0];
-		result.mutez_amount = Number(result.mutez_amount);
+		result.mutez_amount = BigInt(result.mutez_amount);
 		return result;
 	};
 
 	const get_fulfillments = async function ({ message, block_confirmations }) {
 		let result = await db.query(GET_FULFILLMENTS_SQL, [message, block_confirmations])
 		return result.rows.map(row => {
-			row.amount = Number(row.amount);
+			row.amount = BigInt(row.amount);
 			return row;
 		});
 	}

--- a/server/data_access.mjs
+++ b/server/data_access.mjs
@@ -20,13 +20,17 @@ export default function({db, paypoint_schema_name}) {
 	}
 
 	const get_payment = async function({ external_id }) {
-		let result = await db.query(GET_PAYMENT_SQL, [ external_id ]);
-		return result.rows[0];
+		let result = (await db.query(GET_PAYMENT_SQL, [external_id])).rows[0];
+		result.mutez_amount = Number(result.mutez_amount);
+		return result;
 	};
 
 	const get_fulfillments = async function ({ message, block_confirmations }) {
 		let result = await db.query(GET_FULFILLMENTS_SQL, [message, block_confirmations])
-		return result.rows;
+		return result.rows.map(row => {
+			row.amount = Number(row.amount);
+			return row;
+		});
 	}
 
 	return {


### PR DESCRIPTION
Otherwise they're loaded into javascript w/ `node-postgres` as strings. This is a critical bug because it enabled finishing payment intents by paying multiple smaller amounts that when summed are much smaller than the required full amount, but when concatenated in string format become the correct sequence of digits.

For example, a payment intent of the amount of `54730` mutez could be succeeded by first sending `547` mutez, followed by sending `30` mutez in a subsequent transaction.

It also enabled finishing payment intents by paying a one time much smaller amount, because the string comparison `>=` behaves differently than the number comparison `>=` (eg, one could pay off a `54730` mutez payment intent by transferring `6` mutez, because `"6" >= "54730"`). 

---
Alternatively to this PR's proposed fix, this can also be solved by instructing node-postgres to parse numerics as `Bigint` ala:
```
var types = require('pg').types
types.setTypeParser(1700, function(val) {
    return BigInt(val);
});
``` 
But then at least I think the README in this repo should mention this. Lets discuss which is the better way.